### PR TITLE
Add list capital letter rule

### DIFF
--- a/markdown_style_guide.md
+++ b/markdown_style_guide.md
@@ -69,6 +69,7 @@ velit accumsan non.
 
 - **List items** should be indented two spaces (including when working with
   ordered lists)
+- **List items** should begin with a capital letter
 - Lists must be preceded and followed by a blank line
 - Unordered list items should use `-` instead of `*` or `+`.
 


### PR DESCRIPTION
I'd like to propose imposing a "All list items should start with a capital letter rule".

Currently throughout the repository we have a few people using different styles (@jonleung uses both! I use upper case, @Bogidon uses both). I personally find that upper case looks neater, but that may be bias...

Anyway, discuss.

cc: @zachlatta @MaxWofford 